### PR TITLE
feat: Implement About detail page and navigation routing #9

### DIFF
--- a/src/components/sections/About/About.jsx
+++ b/src/components/sections/About/About.jsx
@@ -1,38 +1,113 @@
-import React from 'react';
-import * as S from './style';
+    import React from 'react';
+    import * as S from './style';
+    import { useNavigate } from 'react-router-dom';
 
-function About() {
-    return (
-        <S.AboutContainer>
-            <S.AboutContent>
-                <S.ImageWrapper>
-                    <img/>
-                </S.ImageWrapper>
+    function About({ type = "main" }) {
+        const navigate = useNavigate();
 
-                <S.TextWrapper>
-                    <S.ProfileInfo>
-                        <h2>About me</h2>
-                        <p>소개~~</p>
-                    </S.ProfileInfo>
+        return (
+            type === "main" ? (
+                /* 1. 메인 페이지용 (MainPage) */
+                <S.AboutContainer>
+                    <S.AboutContent>
+                        <S.ImageWrapper>
+                            <img src={null} alt="Profile" />
+                        </S.ImageWrapper>
 
-                    <S.SkillSection>
-                        <S.SkillList>
-                            <span>Java</span>
-                            <span>JSP</span>
-                            <span>React</span>
-                        </S.SkillList>
-                    </S.SkillSection>
+                        <S.TextWrapper>
+                            <S.ProfileInfo>
+                                <h2>About me</h2>
+                                <p>사용자의 경험을 소중히 여기는 프론트엔드 개발자 김유진입니다.</p>
+                            </S.ProfileInfo>
 
-                    <S.ButtonWrapper>
-                        <S.ProjectButton>
-                            더보기
-                        </S.ProjectButton>
-                    </S.ButtonWrapper>
-                </S.TextWrapper>
+                            <S.SkillSection>
+                                <S.SkillList>
+                                    <span>Java</span>
+                                    <span>React</span>
+                                    <span>Emotion</span>
+                                </S.SkillList>
+                            </S.SkillSection>
 
-            </S.AboutContent>
-        </S.AboutContainer>
-    );
-}
+                            <S.ButtonWrapper>
+                                <S.ProjectButton onClick={() => navigate('/portfolio/about')}>
+                                    더보기
+                                </S.ProjectButton>
+                            </S.ButtonWrapper>
+                        </S.TextWrapper>
+                    </S.AboutContent>
+                </S.AboutContainer>
+            ) : (
+                /* 2. 상세 페이지용 (AboutPage) */
+                <S.AboutPageContainer>
+                    <S.TitleSection>
+                        <h1>About Me</h1>
+                        <p>안녕하세요, 끊임없이 성장하는 개발자 김유진입니다.</p>
+                    </S.TitleSection>
 
-export default About;
+                    <S.ProfileSection>
+                        <S.ProfileWrapper>
+                            <img src={null} alt="Profile" />
+                        </S.ProfileWrapper>
+
+                        <S.ProfileDetailInfo>
+                            <h2>Yu Jin Kim</h2>
+                            <ul className="basic-info-list">
+                                <li><span>Birth</span> 19XX.XX.XX</li>
+                                <li><span>Email</span> yujin@example.com</li>
+                                <li><span>Github</span> <a href="https://github.com/..." target="_blank" rel="noreferrer">github.com/yujin</a></li>
+                            </ul>
+                        </S.ProfileDetailInfo>
+                    </S.ProfileSection>
+
+                    <S.GridSection>
+                        <S.GridItem>
+                            <h3>Skills</h3>
+                            <S.SkillGroup>
+                                <h4>Proficient</h4>
+                                <S.SkillTagContainer>
+                                    <span>Java</span>
+                                    <span>React</span>
+                                    <span>Spring</span>
+                                </S.SkillTagContainer>
+                            </S.SkillGroup>
+
+                            <S.SkillGroup>
+                                <h4>Familiar</h4>
+                                <S.SkillTagContainer>
+                                    <span>JavaScript</span>
+                                    <span>Emotion</span>
+                                    <span>SQL</span>
+                                </S.SkillTagContainer>
+                            </S.SkillGroup>
+                        </S.GridItem>
+                        
+                        <S.GridItem>
+                            <h3>Experience</h3>
+                            <div className="history-entry">
+                                <span className="date">2023.01 - 2023.06</span>
+                                <p>웹 프로젝트 개발 및 유지보수</p>
+                            </div>
+                        </S.GridItem>
+
+                        <S.GridItem>
+                            <h3>Education</h3>
+                            <div className="history-entry">
+                                <span className="date">2018.03 - 2022.02</span>
+                                <p>OO대학교 컴퓨터공학 전공</p>
+                            </div>
+                        </S.GridItem>
+
+                        <S.GridItem>
+                            <h3>Certificates</h3>
+                            <div className="history-entry">
+                                <span className="date">2023.05</span>
+                                <p>정보처리기사 자격 취득</p>
+                            </div>
+                        </S.GridItem>
+                    </S.GridSection>
+                </S.AboutPageContainer>
+            )
+        );
+    }
+
+    export default About;

--- a/src/components/sections/About/style.js
+++ b/src/components/sections/About/style.js
@@ -4,17 +4,18 @@ export const AboutContainer = styled.section`
     width: 100%;
     display: flex;
     justify-content: center;
-    padding: 100px 0;
+    padding: 80px 0 100px;
 `;
 
 export const AboutContent = styled.div`
-    width: 90%;
+    width: 100%;
     max-width: 1100px;
-    padding: 30px 50px;
+    padding: 50px;
+    margin: 0 20px; 
     border: 1px solid #2a2a2a;
     border-radius: 40px;
     display: flex;
-    align-items: center;
+    align-items: stretch;
     gap: 80px;
     background-color: #242424;
     box-shadow: 0 20px 40px rgba(0, 0, 0, 0.4);
@@ -22,10 +23,11 @@ export const AboutContent = styled.div`
 
 export const ImageWrapper = styled.div`
     flex: 0 0 280px;
+    height: 280px;
     
     img {
         width: 100%;
-        height: 320px;
+        height: 100%;
         object-fit: cover;
         border-radius: 30px;
     }
@@ -67,7 +69,7 @@ export const SkillSection = styled.div`
         letter-spacing: 1px;
         font-weight: 600;
     }
-    `;
+`;
 
 export const SkillList = styled.div`
     display: flex;
@@ -87,26 +89,201 @@ export const SkillList = styled.div`
             border-color: #555;
         }
     }
-    `;
+`;
 
-    export const ButtonWrapper = styled.div`
+export const ButtonWrapper = styled.div`
+    display: flex;
+    justify-content: flex-end;
+`;
+
+export const ProjectButton = styled.button`
+    margin-top: 20px;
+    background: transparent;
+    border: 1px solid #444;
+    color: #fff;
+    padding: 10px 24px;
+    border-radius: 50px;
+    transition: all 0.3s ease;
+    cursor: pointer;
+
+    &:hover {
+        background: #fff;
+        color: #000;
+        border-color: #fff;
+    }
+`;
+
+export const AboutPageContainer = styled.main`
+    width: 100%;
+    max-width: 1100px;
+    margin: 0 auto;
+    /* padding: 60px 20px; */
+    display: flex;
+    flex-direction: column;
+    color: #ffffff;
+`;
+
+export const TitleSection = styled.section`
+    text-align: center;
+    margin-bottom: 80px;
+
+    h1 {
+        font-size: 56px;
+        font-weight: 800;
+        margin-bottom: 16px;
+        background: linear-gradient(to right, #ffffff, #888888);
+        -webkit-background-clip: text;
+        -webkit-text-fill-color: transparent;
+    }
+
+    p {
+        font-size: 20px;
+        color: #aaaaaa;
+    }
+`;
+
+export const ProfileSection = styled.section`
+    width: 100%;
+    display: flex;
+    align-items: stretch;
+    gap: 60px;
+    background: rgba(255, 255, 255, 0.03);
+    padding: 50px;
+    border-radius: 40px;
+    border: 1px solid rgba(255, 255, 255, 0.05);
+    margin-bottom: 80px;
+`;
+
+export const ProfileWrapper = styled.div`
+    width: 250px;
+    height: 280px;
+    flex-shrink: 0;
+    border-radius: 30px;
+    overflow: hidden;
+    border: 2px solid #333333;
+
+    img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+    }
+`;
+
+export const ProfileDetailInfo = styled.div`
+    h2 {
+        font-size: 32px;
+        margin-bottom: 10px;
+    }
+    .intro {
+        font-size: 18px;
+        color: #007bff;
+        margin-bottom: 24px;
+        font-weight: 500;
+    }
+    ul {
+        list-style: none;
         display: flex;
-        justify-content: flex-end;
-    `;
-    
-    export const ProjectButton = styled.button`
-        margin-top: 20px;
-        background: transparent;
-        border: 1px solid #444;
-        color: #fff;
-        padding: 10px 24px;
-        border-radius: 50px;
-        transition: all 0.3s ease;
-        cursor: pointer;
-    
-        &:hover {
-            background: #fff;
-            color: #000;
-            border-color: #fff;
+        flex-direction: column;
+        gap: 12px;
+        padding: 0;
+
+        li {
+            display: flex;
+            gap: 15px;
+            font-size: 16px;
+            span {
+                width: 80px;
+                color: #666666;
+                font-weight: bold;
+            }
+            a {
+                color: #ffffff;
+                text-decoration: none;
+                &:hover {
+                    color: #007bff;
+                }
+            }
         }
-    `;
+    }
+`;
+
+export const GridSection = styled.section`
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 30px;
+`;
+
+export const GridItem = styled.article`
+    background: rgba(255, 255, 255, 0.02);
+    padding: 30px;
+    border-radius: 20px;
+    border: 1px solid rgba(255, 255, 255, 0.05);
+    transition: transform 0.3s ease;
+
+    &:hover {
+        transform: translateY(-5px);
+        background: rgba(255, 255, 255, 0.04);
+    }
+
+    h3 {
+        font-size: 24px;
+        margin-bottom: 20px;
+        color: #007bff;
+        border-bottom: 1px solid #333333;
+        padding-bottom: 10px;
+    }
+
+    .history-entry {
+        margin-bottom: 15px;
+        .date {
+            display: block;
+            font-size: 14px;
+            color: #888888;
+            margin-bottom: 5px;
+        }
+        p {
+            font-size: 16px;
+            color: #cccccc;
+            line-height: 1.6;
+        }
+    }
+`;
+
+export const SkillGroup = styled.div`
+    margin-bottom: 25px;
+
+    h4 {
+        font-size: 13px;
+        color: #666;
+        margin-bottom: 12px;
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        font-weight: 600;
+    }
+
+    &:last-child {
+        margin-bottom: 0;
+    }
+`;
+
+export const SkillTagContainer = styled.div`
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+
+    span {
+        padding: 6px 14px;
+        border-radius: 8px;
+        font-size: 14px;
+        font-weight: 500;
+        background: rgba(255, 255, 255, 0.05); /* 기본 배경 */
+        color: #ccc;
+        border: 1px solid rgba(255, 255, 255, 0.1);
+        transition: all 0.2s ease;
+
+        &:hover {
+            border-color: #007bff;
+            color: #fff;
+        }
+    }
+`;

--- a/src/pages/AboutPage/AboutPage.jsx
+++ b/src/pages/AboutPage/AboutPage.jsx
@@ -1,9 +1,13 @@
 import React from 'react';
+import * as C from '../../styles/common';
+import About from '../../components/sections/About/About';
 
 function AboutPage() {
-  return (
-    <div>AboutPage</div>
-  );
+    return (
+        <C.MainContent>
+            <About type="detail"/>
+        </C.MainContent>
+    );
 }
 
 export default AboutPage;

--- a/src/pages/MainPage/MainPage.jsx
+++ b/src/pages/MainPage/MainPage.jsx
@@ -1,16 +1,16 @@
 import React from 'react';
-import * as S from './style';
+import * as C from '../../styles/common';
 import Hero from '../../components/sections/Hero/Hero';
 import About from '../../components/sections/About/About';
 import Projects from '../../components/sections/Projects/Projects';
 
 function MainPage() {
 	return (
-		<S.MainContent>
+		<C.MainContent>
 			<Hero/>
 			<About/>
 			<Projects/>
-		</S.MainContent>
+		</C.MainContent>
 	);
 }
 

--- a/src/pages/MainPage/style.js
+++ b/src/pages/MainPage/style.js
@@ -1,9 +1,0 @@
-import styled from "@emotion/styled";
-
-export const MainContent = styled.main`
-    width: 100%;
-    background-color: #1a1a1a;
-    padding-top: 80px;
-    display: flex;
-    flex-direction: column;
-`;

--- a/src/styles/common.js
+++ b/src/styles/common.js
@@ -1,0 +1,9 @@
+import styled from "@emotion/styled";
+
+export const MainContent = styled.main`
+    width: 100%;
+    background-color: #1a1a1a;
+    padding-top: 80px;
+    display: flex;
+    flex-direction: column;
+`;


### PR DESCRIPTION
## ✨ Overview
This PR implements a dedicated **About Page** and refactors the `About` component for high reusability, as defined in #6. 
By utilizing props, the same component now serves both the summary view on the Main page and the detailed view on the About page.

## 🛠 Changes
- **Component Refactoring (Reusability)**: Refactored the `About` component to accept a `type` prop (e.g., `main` vs `about`), allowing it to be reused in both the Main and About pages with different layout logic.
- **AboutPage Implementation**: Developed a comprehensive detailed view in the `pages` folder, including expanded sections for biography, experience, and education.
- **Routing & Navigation**: 
    - Registered the `/about` path in `App.jsx`.
    - Integrated `useNavigate` into the "View More" button on the Main page for a seamless transition.
- **Skill Categorization**: Structured the Skills section to distinguish between **Proficient** and **Familiar** levels, ensuring professional clarity in both views.
- **UI Consistency**: Standardized global styles (box-shadow, border-radius) to ensure a unified design system across different page contexts.

## 🔗 Related Issue
Closes #9